### PR TITLE
Bdcrisco bug fixes

### DIFF
--- a/Data/Scripts/011_Battle/002_Move/006_Move_Effects_080-0FF.rb
+++ b/Data/Scripts/011_Battle/002_Move/006_Move_Effects_080-0FF.rb
@@ -3222,6 +3222,7 @@ class PokeBattle_Move_0F1 < PokeBattle_Move
     itemName = target.itemName
     user.item = target.item
     # Permanently steal the item from wild Pokémon
+    # removed target.item == target.initialItem, this may cause bugs.
     if @battle.wildBattle? && target.opposes? && !user.initialItem
       user.setInitialItem(target.item)
       target.pbRemoveItem

--- a/Data/Scripts/011_Battle/002_Move/006_Move_Effects_080-0FF.rb
+++ b/Data/Scripts/011_Battle/002_Move/006_Move_Effects_080-0FF.rb
@@ -3222,8 +3222,7 @@ class PokeBattle_Move_0F1 < PokeBattle_Move
     itemName = target.itemName
     user.item = target.item
     # Permanently steal the item from wild Pokémon
-    if @battle.wildBattle? && target.opposes? &&
-       target.initialItem==target.item && !user.initialItem
+    if @battle.wildBattle? && target.opposes? && !user.initialItem
       user.setInitialItem(target.item)
       target.pbRemoveItem
     else


### PR DESCRIPTION
fixed thief not working correctly.
previously it would check to see if the wild pokemon's item was == to its initialItem
The problem is that the wild pokemon never has an initialItem so this was always false. 