### PR TITLE
Fixes to sprite downloading pathing

### DIFF
--- a/Data/Scripts/001_Settings.rb
+++ b/Data/Scripts/001_Settings.rb
@@ -22,7 +22,7 @@ module Settings
   #Infinite fusion settings
   NB_POKEMON = 420
   CUSTOM_BATTLERS_FOLDER = "Graphics/CustomBattlers/"
-  CUSTOM_BATTLERS_FOLDER_INDEXED = "Graphics/CustomBattlers/indexed"
+  CUSTOM_BATTLERS_FOLDER_INDEXED = "Graphics/CustomBattlers/indexed/"
   BATTLERS_FOLDER = "Graphics/Battlers/"
   DOWNLOADED_SPRITES_FOLDER = "Graphics/temp/"
   DEFAULT_SPRITE_PATH = "Graphics/Battlers/Special/000.png"

--- a/Data/Scripts/025-Randomizer/randomizer gym leader edit.rb
+++ b/Data/Scripts/025-Randomizer/randomizer gym leader edit.rb
@@ -104,7 +104,7 @@ class PokeBattle_Battle
 end
 
 #######
-# end of class 
+# end of class
 ######
 
 ####methodes utilitaires
@@ -401,10 +401,10 @@ end
 #    i = rand(filesList.length-1)
 #    path = filesList[i]
 #    file  = File.basename(path, ".*")
-#    splitPoke = file.split(".")    
+#    splitPoke = file.split(".")
 #    head = splitPoke[0].to_i
 #    body = splitPoke[1].to_i
-#    return (body*NB_POKEMON)+head 
+#    return (body*NB_POKEMON)+head
 #end
 
 
@@ -412,7 +412,7 @@ def getCustomSpeciesList(allowOnline=true)
   speciesList = []
 
   for num in 1..NB_POKEMON
-    path = Settings::CUSTOM_BATTLERS_FOLDER_INDEXED + "/" + num.to_s + "/*"
+    path = Settings::CUSTOM_BATTLERS_FOLDER_INDEXED + num.to_s + "/*"
     filesList = Dir[path]
     maxDexNumber = (NB_POKEMON * NB_POKEMON) + NB_POKEMON
     maxVal = filesList.length - 1
@@ -695,7 +695,7 @@ def replaceRivalStarterIfNecessary(species)
 end
 
 def fixRivalStarter()
-  #set starter baseform 
+  #set starter baseform
   if $PokemonGlobal.psuedoBSTHash == nil
     psuedoHash = Hash.new
     for i in 0..NB_POKEMON
@@ -738,4 +738,3 @@ def fixRivalStarter()
   pbSet(250, rivalStarter)
   $game_switches[840] = true
 end
-    

--- a/Data/Scripts/050_AddOns/FusionSprites.rb
+++ b/Data/Scripts/050_AddOns/FusionSprites.rb
@@ -195,7 +195,7 @@ def get_unfused_sprite_path(dex_number)
   filename = sprintf("%s.png", dex_number)
 
   normal_path = Settings::BATTLERS_FOLDER + folder + "/" + filename
-  lightmode_path = Settings::BATTLERS_FOLDER +  filename
+  lightmode_path = Settings::BATTLERS_FOLDER + filename
   return normal_path if pbResolveBitmap(normal_path)
   return lightmode_path
 end
@@ -203,7 +203,7 @@ end
 def get_fusion_sprite_path(head_id,body_id)
   #Try local custom sprite
   filename = sprintf("%s.%s.png", head_id, body_id)
-  local_custom_path = Settings::CUSTOM_BATTLERS_FOLDER_INDEXED + "/" + head_id.to_s + "/" +filename
+  local_custom_path = Settings::CUSTOM_BATTLERS_FOLDER_INDEXED + head_id.to_s + "/" +filename
   return local_custom_path if pbResolveBitmap(local_custom_path)
 
   #Try to download custom sprite if none found locally

--- a/Data/Scripts/050_AddOns/HttpCalls.rb
+++ b/Data/Scripts/050_AddOns/HttpCalls.rb
@@ -34,7 +34,7 @@ end
 def download_autogen_sprite(head_id, body_id)
   return nil if $PokemonSystem.download_sprites != 0
   url = "https://raw.githubusercontent.com/Aegide/autogen-fusion-sprites/master/Battlers/{1}/{1}.{2}.png"
-  destPath = _INTL("{1}/{2}",Settings::BATTLERS_FOLDER,head_id)
+  destPath = _INTL("{1}{2}",Settings::BATTLERS_FOLDER,head_id)
   sprite = download_sprite(_INTL(url,head_id,body_id),head_id,body_id,destPath)
   return sprite if sprite
   return nil
@@ -44,7 +44,7 @@ def download_custom_sprite(head_id, body_id)
   return nil if $PokemonSystem.download_sprites != 0
   #base_path = "https://raw.githubusercontent.com/Aegide/custom-fusion-sprites/main/CustomBattlers/{1}.{2}.png"
   url = "https://raw.githubusercontent.com/infinitefusion/sprites/main/CustomBattlers/{1}.{2}.png"
-  destPath= _INTL("{1}/{2}",Settings::CUSTOM_BATTLERS_FOLDER_INDEXED,head_id)
+  destPath= _INTL("{1}{2}",Settings::CUSTOM_BATTLERS_FOLDER_INDEXED,head_id)
   sprite = download_sprite(_INTL(url,head_id,body_id),head_id,body_id,destPath)
   return sprite if sprite
   return nil

--- a/Data/Scripts/050_AddOns/PokedexUtils.rb
+++ b/Data/Scripts/050_AddOns/PokedexUtils.rb
@@ -14,12 +14,12 @@ class PokedexUtils
     head_id = getHeadID(species, body_id)
 
     baseFilename = head_id.to_s + "." + body_id.to_s
-    baseFilePath = Settings::CUSTOM_BATTLERS_FOLDER_INDEXED + "/" + head_id.to_s + "/" + baseFilename + ".png"
+    baseFilePath = Settings::CUSTOM_BATTLERS_FOLDER_INDEXED + head_id.to_s + "/" + baseFilename + ".png"
     if pbResolveBitmap(baseFilePath)
       ret << baseFilePath
     end
     POSSIBLE_ALTS.each { |alt_letter|
-      altFilePath = Settings::CUSTOM_BATTLERS_FOLDER_INDEXED  + "/" + head_id.to_s + "/" + baseFilename + alt_letter + ".png"
+      altFilePath = Settings::CUSTOM_BATTLERS_FOLDER_INDEXED + head_id.to_s + "/" + baseFilename + alt_letter + ".png"
       if pbResolveBitmap(altFilePath)
         ret << altFilePath
       end

--- a/Data/Scripts/999_Main/999_Main.rb
+++ b/Data/Scripts/999_Main/999_Main.rb
@@ -74,8 +74,8 @@ def sortCustomBattlers()
     next if filename == '.' or filename == '..'
     next if !filename.end_with?(".png")
     headNum = filename.split('.')[0]
-    oldPath = Settings::CUSTOM_BATTLERS_FOLDER + "/" + filename
-    newPath = Settings::CUSTOM_BATTLERS_FOLDER_INDEXED + "/" + headNum.to_s + "/" +filename
+    oldPath = Settings::CUSTOM_BATTLERS_FOLDER + filename
+    newPath = Settings::CUSTOM_BATTLERS_FOLDER_INDEXED + headNum.to_s + "/" + filename
     begin
       if File.file?(newPath)
         alreadyExists[oldPath] = newPath


### PR DESCRIPTION
Issue: #72 
Various messages on the game's Discord's #tech-support channel brought this issue to my attention where people we getting missing directory errors when the game would try to download sprites. There was a simple inconsistency in [the sprite folder paths](Data/Scripts/001_Settings.rb) where `CustomBattlers/indexed/` was missing the ending slash that all the other paths had, which was not always accounted for in other scripts. I went through all references to any of these sprite path constants and made sure the conventions matched and then ran several sprite downloading tests for both autogen and custom sprites to check that these changes work.
I am creating this pull request to the default branch, which is set to `e19-release-beta` instead of `master`, and I'm assuming that's intentional, but the target branch can always be changed.