### PR TITLE
Correcting Ability Capsules

### DIFF
--- a/Data/Scripts/013_Items/002_Item_Effects.rb
+++ b/Data/Scripts/013_Items/002_Item_Effects.rb
@@ -1068,7 +1068,8 @@ ItemHandlers::UseOnPokemon.add(:ABILITYCAPSULE, proc { |item, pkmn, scene|
   if scene.pbConfirm(_INTL("Would you like to change {1}'s Ability to {2}?",
                            pkmn.name, newabilname))
     pkmn.ability_index = newabil
-    scene.pbRefresh
+    pkmn.ability = GameData::Ability.get((newabil == 0) ? abil1 : abil2).id
+	  scene.pbHardRefresh
     scene.pbDisplay(_INTL("{1}'s Ability changed to {2}!", pkmn.name, newabilname))
     next true
   end


### PR DESCRIPTION
Ability capsules were only updating the ID of the ability the pokemon thought it had, and not actually changing the pokemon's ability.