### PR TITLE
Fixing the pickup ability

### DIFF
--- a/Data/Scripts/012_Overworld/002_Battle triggering/001_Overworld_BattleStarting.rb
+++ b/Data/Scripts/012_Overworld/002_Battle triggering/001_Overworld_BattleStarting.rb
@@ -688,7 +688,7 @@ end
 def pbDynamicItemList(*args)
   ret = []
   for i in 0...args.length
-    ret.push(i) if GameData::Item.exists?(args[i])
+    ret.push(args[i]) if GameData::Item.exists?(args[i])
   end
   return ret
 end


### PR DESCRIPTION
pickup ability was accidentally only grabbing the item by number, rather than by value. This change corrects it so it now grabs item by name. Credit to McPNorf on Reddit