### PR TITLE
lantern continues being active after battle

### DIFF
--- a/Data/Scripts/050_AddOns/New Items effects.rb
+++ b/Data/Scripts/050_AddOns/New Items effects.rb
@@ -81,6 +81,7 @@ def useLantern()
   end
   Kernel.pbMessage(_INTL("The Lantern illuminated the cave!"))
   darkness.radius += 176
+  $PokemonGlobal.flashUsed = true
   while darkness.radius < 176
     Graphics.update
     Input.update


### PR DESCRIPTION
Before, the lantern needs to be reactivated after each battle. Now, it remains on, just like flash!