### PR TITLE
fix to bug regarding same icon for multiple fusions

### DIFF
--- a/Data/Scripts/013_Items/004_1_PokeradarUI.rb
+++ b/Data/Scripts/013_Items/004_1_PokeradarUI.rb
@@ -112,14 +112,20 @@ class PokeRadar_UI
     bitmap1 = AnimatedBitmap.new(GameData::Species.icon_filename(headPoke))
     bitmap2 = AnimatedBitmap.new(GameData::Species.icon_filename(bodyPoke))
 
+    bitmapFileName = sprintf("Graphics/Pokemon/FusionIcons/icon%03d", pokemonId)
+    headPokeFileName = GameData::Species.icon_filename(headPoke)
+    bitmapPath = sprintf("%s.png", bitmapFileName)
+    IO.copy_stream(headPokeFileName, bitmapPath)
+    result_bitmap = AnimatedBitmap.new(bitmapPath)
+
     for i in 0..bitmap1.width-1
       for j in ((bitmap1.height / 2) + Settings::FUSION_ICON_SPRITE_OFFSET)..bitmap1.height-1
         temp = bitmap2.bitmap.get_pixel(i, j)
-        bitmap1.bitmap.set_pixel(i, j, temp)
+        result_bitmap.bitmap.set_pixel(i, j, temp)
       end
     end
     icon = IconSprite.new(x, y)
-    icon.setBitmapDirectly(bitmap1)
+    icon.setBitmapDirectly(result_bitmap)
     return icon
   end
 

--- a/Data/Scripts/014_Pokemon/001_Pokemon-related/003_Pokemon_Sprites.rb
+++ b/Data/Scripts/014_Pokemon/001_Pokemon-related/003_Pokemon_Sprites.rb
@@ -187,13 +187,20 @@ class PokemonIconSprite < SpriteWrapper
     icon1 = AnimatedBitmap.new(GameData::Species.icon_filename(headPoke))
     icon2 = AnimatedBitmap.new(GameData::Species.icon_filename(bodyPoke))
 
+    dexNum = getDexNumberForSpecies(@pokemon.species)
+    bitmapFileName = sprintf("Graphics/Pokemon/FusionIcons/icon%03d", dexNum)
+    headPokeFileName = GameData::Species.icon_filename(headPoke)
+    bitmapPath = sprintf("%s.png", bitmapFileName)
+    IO.copy_stream(headPokeFileName, bitmapPath)
+    result_icon = AnimatedBitmap.new(bitmapPath)
+
     for i in 0..icon1.width-1
       for j in ((icon1.height / 2) + Settings::FUSION_ICON_SPRITE_OFFSET)..icon1.height-1
         temp = icon2.bitmap.get_pixel(i, j)
-        icon1.bitmap.set_pixel(i, j, temp)
+        result_icon.bitmap.set_pixel(i, j, temp)
       end
     end
-    return icon1
+    return result_icon
   end
 
   def setOffset(offset = PictureOrigin::Center)

--- a/Data/Scripts/016_UI/017_UI_PokemonStorage.rb
+++ b/Data/Scripts/016_UI/017_UI_PokemonStorage.rb
@@ -34,13 +34,20 @@ class PokemonBoxIcon < IconSprite
     icon1 = AnimatedBitmap.new(GameData::Species.icon_filename(headPoke))
     icon2 = AnimatedBitmap.new(GameData::Species.icon_filename(bodyPoke))
 
+    dexNum = getDexNumberForSpecies(species)
+    bitmapFileName = sprintf("Graphics/Pokemon/FusionIcons/icon%03d", dexNum)
+    headPokeFileName = GameData::Species.icon_filename(headPoke)
+    bitmapPath = sprintf("%s.png", bitmapFileName)
+    IO.copy_stream(headPokeFileName, bitmapPath)
+    result_icon = AnimatedBitmap.new(bitmapPath)
+
     for i in 0..icon1.width - 1
       for j in ((icon1.height / 2) + Settings::FUSION_ICON_SPRITE_OFFSET)..icon1.height - 1
         temp = icon2.bitmap.get_pixel(i, j)
-        icon1.bitmap.set_pixel(i, j, temp)
+        result_icon.bitmap.set_pixel(i, j, temp)
       end
     end
-    return icon1
+    return result_icon
   end
 
   def release


### PR DESCRIPTION
What is the bug?
If multiple Pokemon are fused with the same head, then all of their icons e.g. in the PC or the party will be the same.

How can this bug be reproduced?
Catch multiple of the same Pokemon, e.g. pidgey, and several different Pokemon. Now fuse all but one of the pidgeys so that all fusions have pidgey as the head. Now all pokemon with pidgey as the head should have the same icon, even though they are completely different pokemon.

What is the cause of this issue?
There are three functions with the name 'createFusionIcon' in three different files: 'Scripts/013_Items/004_1_PokeradarUI.rb', 'Scripts/014_Pokemon/001_Pokemon-related/003_Pokemon_Sprites.rb' and 'Scripts/016_UI/017_UI_PokemonStorage.rb'.
These functions are used to create the icons. They currently do this by loading the head-icon, editing it with half of the body-icon and returning the icon. This causes all pokemon that use the head-icon to use this new icon.

What is the solution to this problem?
The head-icon must not be edited. Instead, a new icon for the fusion needs to be created.
I have never programmed in Ruby before, so I have been very careful with my changes. I have modified the 'createFusionIcon'-function, so that it copies the icon-file of the head-pokemon to a new folder. This new file is then loaded and edited to have half of the body-icon.
This solution isn't optimal because new files are created everytime a fusion-icon is created. A better solution would be to create a new empty AnimatedBitmap object and copy half of each icon onto this new temporary object. However, the AnimatedBitmap-constructor currently doesn't allow the creation of an empty icon and I don't have enough experience with either Ruby or the Project to foresee any issues that may arise.

I wasn't able to test the changes in the development environment as some files appear to be missing from the github-repository. The changes work in my normal game directory.  It may be necessary to add the following directory: 'Graphics/Pokemon/FusionIcons'.