### PR TITLE
Fix Static/Magnet Pull wild encounter modifier

### DIFF
--- a/Data/Scripts/012_Overworld/002_Battle triggering/003_Overworld_WildEncounters.rb
+++ b/Data/Scripts/012_Overworld/002_Battle triggering/003_Overworld_WildEncounters.rb
@@ -293,7 +293,7 @@ class PokemonEncounters
       if favored_type
         new_enc_list = []
         enc_list.each do |enc|
-          species_data = GameData::Species.get(enc[0])
+          species_data = GameData::Species.get(enc[1])
           t1 = species_data.type1
           t2 = species_data.type2
           new_enc_list.push(enc) if t1 == favored_type || t2 == favored_type


### PR DESCRIPTION
The `Static` and `Magnet Pull` pokemon abilities have a side effect of having a 50% chance of encountering exclusively Electric / Steel type pokemon respectively, however it was not working properly because it was checking the types of species using the encounter rate (encounter index 0) instead of the encounter species (encounter index 1), causing it to check the types of random unrelated pokemon.