### PR TITLE
Assign ability index when capturing Pokemon with Ability Ball

### DIFF
--- a/Data/Scripts/050_AddOns/New Balls.rb
+++ b/Data/Scripts/050_AddOns/New Balls.rb
@@ -30,7 +30,8 @@ next catchRate
 })
 BallHandlers::OnCatch.add(:ABILITYBALL,proc{|ball,battle,pokemon|
   species = getSpecies(dexNum(pokemon))
-  pokemon.ability= species.hidden_abilities[-1]
+  pokemon.ability = species.hidden_abilities[-1]
+  pokemon.ability_index = 2 + species.hidden_abilities.size - 1
 })
 
 #VIRUS BALL 27  - give pokerus


### PR DESCRIPTION
This means that Pokemon will no longer lose their Hidden Abilities when unfusing or evolving into Pokemon that has a different Hidden Ability.

I'm not sure whether it's a bug or it's intentionally designed like this, if it's intentional feel free to reject this change (it's easy enough that I figured it's probably easier to just submit it).