### PR TITLE
Allow changing gender of single gender Pokemon

### DIFF
--- a/Data/Scripts/014_Pokemon/001_Pokemon.rb
+++ b/Data/Scripts/014_Pokemon/001_Pokemon.rb
@@ -448,12 +448,12 @@ class Pokemon
 
   # Makes this Pokémon male.
   def makeMale
-    self.gender = 0;
+    @gender = 0
   end
 
   # Makes this Pokémon female.
   def makeFemale
-    self.gender = 1;
+    @gender = 1
   end
 
   # @return [Boolean] whether this Pokémon is male


### PR DESCRIPTION
Before that change, Gender Stone and Gender Ball didn't actually do anything other than being wasted with single-gender Pokemon such as Chansey and fusions (which are all internally genderless).

An alternative patch would be to modify Gender Stone to check whether Pokemon is single-gender before it can be used, if this behavior is intended.