### PR TITLE
pokeradar crash createFusionIcon

### DIFF
--- a/Data/Scripts/013_Items/004_1_PokeradarUI.rb
+++ b/Data/Scripts/013_Items/004_1_PokeradarUI.rb
@@ -111,7 +111,7 @@ class PokeRadar_UI
 
     bitmap1 = AnimatedBitmap.new(GameData::Species.icon_filename(headPoke))
     bitmap2 = AnimatedBitmap.new(GameData::Species.icon_filename(bodyPoke))
-    dexNum = getDexNumberForSpecies(@pokemon.species)
+    dexNum = getDexNumberForSpecies(pokemonId)
     ensureFusionIconExists()
     bitmapFileName = sprintf("Graphics/Pokemon/FusionIcons/icon%03d", dexNum)
     headPokeFileName = GameData::Species.icon_filename(headPoke)


### PR DESCRIPTION
When pokeradar is used around fused wild pokemon: 
@pokemon is nil at the time @pokemon.species is called, resulting in a crash.

Solution:
pokemonId is supplied by the method so that can be used to get the dexNum instead
