### PR TITLE
Backup save when saving

### DIFF
--- a/Data/Scripts/050_AddOns/MultiSaves.rb
+++ b/Data/Scripts/050_AddOns/MultiSaves.rb
@@ -285,7 +285,9 @@ class PokemonLoadScreen
   def try_load_backup(file_path)
     if File.file?(file_path + ".bak")
       pbMessage(_INTL("The save file is corrupt. A backup will be loaded."))
-      save_data = load_save_file(file_path + ".bak")
+      file_copy(file_path, SaveData.get_backup_file_path)
+      File.rename(file_path + '.bak', file_path)
+      save_data = load_save_file(file_path)
     else
       self.prompt_save_deletion(file_path)
       return {}
@@ -693,6 +695,9 @@ module Game
     $Trainer.save_slot = slot unless auto
     $Trainer.last_time_saved = Time.now
     begin
+      if File.exists?(file_path)
+        file_copy(file_path, file_path + '.bak')
+      end
       SaveData.save_to_file(file_path)
       Graphics.frame_reset
     rescue IOError, SystemCallError


### PR DESCRIPTION
There are a lot of issues in bug reports involving corrupted saves. The way saving currently works, if anything were to happen in middle of saving process, the save is permanently lost, which is probably bad in a game like this. To avoid this issue, I modified the saving process to make a backup first.

Additionally, I modified backup restoration process to avoid leaving corrupted save as is, which would be bad for backup process, as it would overwrite valid backup with a corrupted backup after first save which necessitated backup restoration. The corrupted is moved to `Backup000` to avoid deleting the corrupted save without asking.