### PR TITLE
have pokemon keep moves upon unfusing with supersplicers

### DIFF
--- a/Data/Scripts/014_Pokemon/001_Pokemon.rb
+++ b/Data/Scripts/014_Pokemon/001_Pokemon.rb
@@ -794,15 +794,8 @@ class Pokemon
   end
 
   def pokemon_can_learn_move(species_data, move_data)
-    is_level_up_move = false
-    for i in 0...species_data.moves.length
-      if (species_data.moves[i][1] == move_data.id) # [0] level, [1] move
-        is_level_up_move = true
-        break
-      end
-    end
     return species_data.tutor_moves.include?(move_data.id) ||
-      is_level_up_move ||
+      species_data.moves.any?{|m| m[1] == move_data.id} ||
       species_data.egg_moves.include?(move_data.id)
   end
 
@@ -819,6 +812,15 @@ class Pokemon
     baby = pbGetBabySpecies(self.species)
     moves = pbGetSpeciesEggMoves(baby)
     return true if moves.size >= 1
+  end
+
+  def is_move_legal?(move_id)
+    move_data = GameData::Move.try_get(move_id)
+    baby = GameData::Species.get(species_data.get_baby_species)
+    prevo = GameData::Species.get(species_data.get_previous_species)
+    return pokemon_can_learn_move(baby, move_data) ||
+      pokemon_can_learn_move(prevo, move_data) || 
+      pokemon_can_learn_move(self.species_data, move_data)
   end
 
   #=============================================================================

--- a/Data/Scripts/014_Pokemon/001_Pokemon.rb
+++ b/Data/Scripts/014_Pokemon/001_Pokemon.rb
@@ -794,8 +794,15 @@ class Pokemon
   end
 
   def pokemon_can_learn_move(species_data, move_data)
+    is_level_up_move = false
+    for i in 0...species_data.moves.length
+      if (species_data.moves[i][1] == move_data.id) # [0] level, [1] move
+        is_level_up_move = true
+        break
+      end
+    end
     return species_data.tutor_moves.include?(move_data.id) ||
-      species_data.moves.include?(move_data.id) ||
+      is_level_up_move ||
       species_data.egg_moves.include?(move_data.id)
   end
 

--- a/Data/Scripts/050_AddOns/New Items effects.rb
+++ b/Data/Scripts/050_AddOns/New Items effects.rb
@@ -1536,20 +1536,12 @@ def pbUnfuse(pokemon, scene, supersplicers, pcPosition = nil)
       end
 
       if (supersplicers) # check for legal moves and give them to unfused pokes
-        poke1_baby = GameData::Species.get(poke1.species_data.get_baby_species)
-        poke1_prevo = GameData::Species.get(poke1.species_data.get_previous_species)
-        poke2_baby = GameData::Species.get(poke2.species_data.get_baby_species)
-        poke2_prevo = GameData::Species.get(poke2.species_data.get_previous_species)
 
         for i in 0...pokemon.moves.length
-          if (poke1.pokemon_can_learn_move(poke1_baby, pokemon.moves[i]) ||
-              poke1.pokemon_can_learn_move(poke1_prevo, pokemon.moves[i]) || 
-              poke1.pokemon_can_learn_move(poke1.species_data, pokemon.moves[i]))
+          if poke1.is_move_legal?(pokemon.moves[i].id) && !poke1.hasMove?(pokemon.moves[i].id)
             poke1.moves[i] = pokemon.moves[i]
           end
-          if (poke2.pokemon_can_learn_move(poke2_baby, pokemon.moves[i]) || 
-              poke2.pokemon_can_learn_move(poke2_prevo, pokemon.moves[i]) || 
-              poke2.pokemon_can_learn_move(poke2.species_data, pokemon.moves[i]))
+          if poke2.is_move_legal?(pokemon.moves[i].id) && !poke2.hasMove?(pokemon.moves[i].id)
             poke2.moves[i] = pokemon.moves[i]
           end
         end

--- a/Data/Scripts/050_AddOns/New Items effects.rb
+++ b/Data/Scripts/050_AddOns/New Items effects.rb
@@ -1535,6 +1535,27 @@ def pbUnfuse(pokemon, scene, supersplicers, pcPosition = nil)
         poke2.debug_shiny = false
       end
 
+      if (supersplicers) # check for legal moves and give them to unfused pokes
+        poke1_baby = GameData::Species.get(poke1.species_data.get_baby_species)
+        poke1_prevo = GameData::Species.get(poke1.species_data.get_previous_species)
+        poke2_baby = GameData::Species.get(poke2.species_data.get_baby_species)
+        poke2_prevo = GameData::Species.get(poke2.species_data.get_previous_species)
+
+        for i in 0...pokemon.moves.length
+          if (poke1.pokemon_can_learn_move(poke1_baby, pokemon.moves[i]) ||
+              poke1.pokemon_can_learn_move(poke1_prevo, pokemon.moves[i]) || 
+              poke1.pokemon_can_learn_move(poke1.species_data, pokemon.moves[i]))
+            poke1.moves[i] = pokemon.moves[i]
+          end
+          if (poke2.pokemon_can_learn_move(poke2_baby, pokemon.moves[i]) || 
+              poke2.pokemon_can_learn_move(poke2_prevo, pokemon.moves[i]) || 
+              poke2.pokemon_can_learn_move(poke2.species_data, pokemon.moves[i]))
+            poke2.moves[i] = pokemon.moves[i]
+          end
+        end
+
+      end
+
       if $Trainer.party.length >= 6
         if (keepInParty == 0)
           $PokemonStorage.pbStoreCaught(poke2)


### PR DESCRIPTION
This makes it so pokemon unfused with supersplicers keep any moves that are in their learnset or any previous evolution's learnset.

It also addresses a bug in `pokemon_can_learn_move()`. The include comparison doesn't work on `species_data.moves` because it's a 2d array with moves and a required level.
 
Edit: refactored into `Pokemon.is_move_legal()` 