### PR TITLE
Make black and white flute effects persist when entering a new route

### DIFF
--- a/Data/Scripts/012_Overworld/001_Overworld.rb
+++ b/Data/Scripts/012_Overworld/001_Overworld.rb
@@ -283,7 +283,13 @@ Events.onMapChange += proc { |_sender, e|
   if new_map_metadata && new_map_metadata.teleport_destination
     $PokemonGlobal.healingSpot = new_map_metadata.teleport_destination
   end
-  $PokemonMap.clear if $PokemonMap
+  if $PokemonMap
+    blackFluteUsed = $PokemonMap.blackFluteUsed
+    whiteFluteUsed = $PokemonMap.whiteFluteUsed
+    $PokemonMap.clear
+    $PokemonMap.blackFluteUsed = blackFluteUsed
+    $PokemonMap.whiteFluteUsed = whiteFluteUsed
+  end
   $PokemonEncounters.setup($game_map.map_id) if $PokemonEncounters
   $PokemonGlobal.visitedMaps[$game_map.map_id] = true
   next if old_map_ID == 0 || old_map_ID == $game_map.map_id

--- a/Data/Scripts/013_Items/002_Item_Effects.rb
+++ b/Data/Scripts/013_Items/002_Item_Effects.rb
@@ -148,17 +148,19 @@ Events.onStepTaken += proc {
 
 ItemHandlers::UseInField.add(:BLACKFLUTE, proc { |item|
   pbUseItemMessage(item)
-  pbMessage(_INTL("Wild Pokémon will be repelled."))
-  $PokemonMap.blackFluteUsed = true
+  message = $PokemonMap.blackFluteUsed ? "Wild Pokemon will no longer be repelled.": "Wild Pokémon will be repelled."
+  pbMessage(_INTL(message))
+  $PokemonMap.blackFluteUsed = !$PokemonMap.blackFluteUsed
   $PokemonMap.whiteFluteUsed = false
   next 1
 })
 
 ItemHandlers::UseInField.add(:WHITEFLUTE, proc { |item|
   pbUseItemMessage(item)
-  pbMessage(_INTL("Wild Pokémon will be lured."))
+  message = $PokemonMap.whiteFluteUsed ? "Wild Pokemon will no longer be lured.": "Wild Pokémon will be lured."
+  pbMessage(_INTL(message))
+  $PokemonMap.whiteFluteUsed = !$PokemonMap.whiteFluteUsed
   $PokemonMap.blackFluteUsed = false
-  $PokemonMap.whiteFluteUsed = true
   next 1
 })
 


### PR DESCRIPTION
 - Black and white flute now able to be toggled on and off (by simply using the item again)
 - Entering a new route will no longer erase the effect of the currently active flute