### PR TITLE
DNAReverser Removal Bug

### DIFF
--- a/Data/Scripts/016_UI/017_UI_PokemonStorage.rb
+++ b/Data/Scripts/016_UI/017_UI_PokemonStorage.rb
@@ -2368,8 +2368,8 @@ class PokemonStorageScreen
     end
     if Kernel.pbConfirmMessageSerious(_INTL("Should {1} be reversed?", pokemon.name))
       reverseFusion(pokemon)
+      $PokemonBag.pbDeleteItem(:DNAREVERSER) if $PokemonBag.pbQuantity(:INFINITEREVERSERS) <= 0
     end
-    $PokemonBag.pbDeleteItem(:DNAREVERSER) if $PokemonBag.pbQuantity(:INFINITEREVERSERS) <= 0
   end
 
   def pbUnfuseFromPC(selected)


### PR DESCRIPTION
When selecting the "Reverse" option on a fusion while in the PC's Pokémon Storage, if "No" is selected in the confirmation dialogue, the player still loses a DNAReverser. This bug was reported on the official Discord Channel here:

https://discord.com/channels/302153478556352513/1244309081381015693

The issue is that the `pbDeleteItem` method gets called independently from the answer obtained by the `pbConfirmMessageSerious` prompt. Moving the item deletion into the same branching condition as the reversal itself should fix the issue.