### PR TITLE
Prevent F12 reset crash when outside of battle

### DIFF
--- a/Data/Scripts/999_Main/999_Main.rb
+++ b/Data/Scripts/999_Main/999_Main.rb
@@ -159,6 +159,9 @@ def mainFunctionDebug
     pbPrintException($!) if !$DEBUG
     pbEmergencySave
     raise
+  rescue Reset
+    $scene = nil
+    raise
   end
 end
 


### PR DESCRIPTION
Fixes the fatal error caused by using the F12 soft reset outside of battle.
(Just unsets the $scene global variable, which'll be reinitialised when the game launches again.)