### PR TITLE
Fix for Drain vs Liquid Ooze

### DIFF
--- a/Data/Scripts/011_Battle/001_Battler/003_Battler_ChangeSelf.rb
+++ b/Data/Scripts/011_Battle/001_Battler/003_Battler_ChangeSelf.rb
@@ -30,7 +30,7 @@ class PokeBattle_Battler
   end
 
   def pbRecoverHPFromDrain(amt,target,msg=nil)
-    if target.hasActiveAbility?(:LIQUIDOOZE)
+    if target.hasActiveAbility?(:LIQUIDOOZE, true)
       @battle.pbShowAbilitySplash(target)
       pbReduceHP(amt)
       @battle.pbDisplay(_INTL("{1} sucked up the liquid ooze!",pbThis))


### PR DESCRIPTION
When a draining move KOs a Pokemon with Liquid Ooze, the ability would not activate. This fixes that.