### PR TITLE
Fixes player dismounting bike when using the Teleporter

### DIFF
--- a/Data/Scripts/052_AddOns/New Items effects.rb
+++ b/Data/Scripts/052_AddOns/New Items effects.rb
@@ -129,7 +129,8 @@ def useTeleporter()
   else
     Kernel.pbMessage(_INTL("{1} used the teleporter!", $Trainer.name))
     pbFadeOutIn(99999) {
-      Kernel.pbCancelVehicles
+      # The map ID parameter ensures the player stays on the bike when teleporting
+      Kernel.pbCancelVehicles($PokemonTemp.flydata[0])
       $game_temp.player_new_map_id = $PokemonTemp.flydata[0]
       $game_temp.player_new_x = $PokemonTemp.flydata[1]
       $game_temp.player_new_y = $PokemonTemp.flydata[2]


### PR DESCRIPTION
Added the map ID parameter to the `pbCancelVehicles` call, which was already capable of keeping the player on the bike