### PR TITLE
Options UI: Fix descriptions not updating correctly

### DIFF
--- a/Data/Scripts/016_UI/015_UI_Options.rb
+++ b/Data/Scripts/016_UI/015_UI_Options.rb
@@ -129,13 +129,14 @@ end
 #===============================================================================
 #
 #===============================================================================
-class NumberOption
+class NumberOption < Option
   include PropertyMixin
   attr_reader :name
   attr_reader :optstart
   attr_reader :optend
 
-  def initialize(name, optstart, optend, getProc, setProc)
+  def initialize(name, optstart, optend, getProc, setProc, description="")
+    super(description)
     @name = name
     @optstart = optstart
     @optend = optend
@@ -212,6 +213,7 @@ class Window_PokemonOption < Window_DrawableCommand
     @mustUpdateDescription = false
     @selected_position = 0
     @allow_arrows_jump = false
+    @is_first_update = true
     for i in 0...@options.length
       @optvalues[i] = 0
     end
@@ -319,23 +321,43 @@ class Window_PokemonOption < Window_DrawableCommand
     oldindex = self.index
     @mustUpdateOptions = false
     super
-    dorefresh = (self.index != oldindex)
+
+    if @is_first_update
+      # Needed for displaying the description of the initially selected option correctly
+      @selected_position = self[self.index]
+      @mustUpdateOptions = true
+      @mustUpdateDescription = true
+      @is_first_update = false
+      refresh
+      return
+    end
+
     if self.active && self.index < @options.length
       if Input.repeat?(Input::LEFT)
         self[self.index] = @options[self.index].prev(self[self.index])
-        dorefresh =
-          @selected_position = self[self.index]
-        @mustUpdateOptions = true
-        @mustUpdateDescription = true
-      elsif Input.repeat?(Input::RIGHT)
-        self[self.index] = @options[self.index].next(self[self.index])
-        dorefresh = true
         @selected_position = self[self.index]
         @mustUpdateOptions = true
         @mustUpdateDescription = true
+        refresh if self[self.index]
+        return
+      end
+      if Input.repeat?(Input::RIGHT)
+        self[self.index] = @options[self.index].next(self[self.index])
+        @selected_position = self[self.index]
+        @mustUpdateOptions = true
+        @mustUpdateDescription = true
+        refresh
+        return
+      end
+      if Input.repeat?(Input::UP) || Input.repeat?(Input::DOWN)
+        @selected_position = self[self.index]
+        @mustUpdateOptions = true
+        @mustUpdateDescription = true
+        refresh
+        return
       end
     end
-    refresh if dorefresh
+    refresh if (self.index != oldindex)
   end
 end
 


### PR DESCRIPTION
The UI options menu (afaik only used for the settings menu and selecting the nature/ability after fusing) has some cases where the description is not updated correctly. These cases are:

- When entering the menu (initial state)
- When going up or down in those menus

# Before

## Case 1
In the first case no description is loaded at all, and therefor shows the placeholder "Speech frame 1" for settings

![Settings](https://i.gyazo.com/decf551ca66e157ffdcb4c46210b60ea.png)

and for fusing the description box is just empty

![Fusion](https://i.gyazo.com/969f52bc9575f976a60ee0928dbde453.png)

## Case 2
In this case going up or down in these menus will update the option, but not the position of the selected option.
Due to this, the description shown will be the one matching the position on that item. If there an option is selected that doesn't have a description at that position, it will be empty or "Speech Frame 1"

Settings should show "running" description instead of "walking". Was triggered by changing "Text Speed" to "Normal" and then pressing "Up".

![Settings](https://i.gyazo.com/fe9d558bacf4a85bc6450df35a8c608b.png)

Fusing menu shows "Solor Power" description when it should show "Cute Charm" description instead

![Fusion](https://i.gyazo.com/6d98ac4faf62cb67e3173c9167de1f13.png)


# After

## Case 1
Now on entering one of these menus, the description is reloaded

Settings:

![Settings](https://i.gyazo.com/c679c999c43471d8669a411a694b73c6.png)

Fusing:

![Fusing](https://i.gyazo.com/f63b47191709b035cfdbc4f93ad3142a.png)

## Case 2
Now pressing up or down in these menus will also reload the description.

Settings:

![Settings](https://i.gyazo.com/89694d01bec637faebaac4856e4ec206.png)

Fusing:

![Fusing](https://i.gyazo.com/10705f31c5d301e4aa0404fb1161d39b.png)


# Other changes
- To fix case 2 for fusing there was another change needed. The condition for if a reload should happen on pressing left was not correct, I assume a typo.
- Improved the update methode in general by restructuring it and adding early returns for each case so as little time as possible is wasted.
- Added optional parameter "description" for EnumOption class. This is in preparation for an upcoming PR, might aswell add it here already.