### PR TITLE
Multiline Spriter Credits

### DIFF
--- a/Data/Scripts/048_Fusion/PokemonFusion.rb
+++ b/Data/Scripts/048_Fusion/PokemonFusion.rb
@@ -969,9 +969,12 @@ def drawSpriteCredits(pif_sprite, viewport)
   label_base_color = Color.new(98, 231, 110)
   label_shadow_color = Color.new(27, 169, 40)
 
-  #label_shadow_color = Color.new(33, 209, 50)
-  text = _INTL("Sprite by {1}", author_name)
-  textpos = [[text, x, y, 2, label_base_color, label_shadow_color]]
+  split_name = splitSpriteCredits(_INTL("Sprite by {1}", author_name), overlay, overlay.width - 20)
+  line_height = overlay.text_size(author_name).height
+  textpos = split_name.each_with_index.map { |name, index|
+    y = 240 - ((split_name.length - (index + 1)) * line_height)
+    [name, x, y, 2, label_base_color, label_shadow_color]
+  }
   pbDrawTextPositions(overlay, textpos)
 end
 

--- a/Data/Scripts/052_AddOns/GeneralUtils.rb
+++ b/Data/Scripts/052_AddOns/GeneralUtils.rb
@@ -508,3 +508,58 @@ def new_spritepack_was_released()
   end
   return false
 end
+
+def splitSpriteCredits(name, bitmap, max_width)
+  name_full_width = bitmap.text_size(name).width
+  # use original name if can fit on one line
+  return [ name ] if name_full_width <= max_width
+
+  temp_string = name
+  name_split = []
+
+  # split name by collab separator " & " nearest to max width
+  start_pos = temp_string.index(' & ')
+  temp_pos = nil
+  while start_pos && (bitmap.text_size(temp_string).width > max_width)
+    substring_width = bitmap.text_size(temp_string[0, start_pos]).width
+    if substring_width > max_width
+      name_split << temp_string[0, temp_pos].strip
+      temp_string = temp_string[(temp_pos + 1)..].strip
+      start_pos = temp_string.index(' & ')
+      temp_pos = nil
+      next
+    end
+
+    temp_pos = start_pos
+    start_pos = temp_string.index(' & ', start_pos + 1)
+  end
+
+  # append remainder of " & " split if within max width
+  if temp_pos != nil
+    name_split << temp_string[0, temp_pos].strip
+    temp_string = temp_string[(temp_pos + 1)..].strip
+  end
+
+  # split remaining string by space
+  temp_pos = nil
+  if (bitmap.text_size(temp_string).width > max_width) && (start_pos = temp_string.index(' '))
+    while start_pos && (bitmap.text_size(temp_string).width > max_width)
+      substring_width = bitmap.text_size(temp_string[0, start_pos]).width
+      if substring_width > max_width
+        name_split << temp_string[0, temp_pos].strip
+        temp_string = temp_string[(temp_pos + 1)..].strip
+        start_pos = temp_string.index(' ')
+        temp_pos = nil
+        next
+      end
+
+      temp_pos = start_pos
+      start_pos = temp_string.index(' ', start_pos + 1)
+    end
+  end
+
+  # append remaining text, even if too long for screen
+  name_split << temp_string if temp_string != ''
+
+  return name_split
+end

--- a/Data/Scripts/052_AddOns/UI_Pokedex_SpritesPage.rb
+++ b/Data/Scripts/052_AddOns/UI_Pokedex_SpritesPage.rb
@@ -227,63 +227,6 @@ class PokemonPokedexInfo_Scene
     update_selected
   end
 
-  def splitSpriteCredits(name)
-    max_width = @creditsOverlay.width - 20
-    name_full_width = @creditsOverlay.text_size(name).width
-    # use original name if can fit on one line
-    return [ name ] if name_full_width <= max_width
-
-    temp_string = name
-    name_split = []
-
-    # split name by collab separator " & " up to screen width
-    start_pos = temp_string.index(' & ')
-    temp_pos = nil
-    while start_pos && (@creditsOverlay.text_size(temp_string).width > max_width)
-      substring_width = @creditsOverlay.text_size(temp_string[0, start_pos]).width
-      if substring_width > max_width
-        name_split << temp_string[0, temp_pos].strip
-        temp_string = temp_string[(temp_pos + 1)..].strip
-        start_pos = temp_string.index(' & ')
-        temp_pos = nil
-        next
-      end
-
-      temp_pos = start_pos
-      start_pos = temp_string.index(' & ', start_pos + 1)
-    end
-
-    # append remainder of " & " split if within max width
-    if temp_pos != nil
-      name_split << temp_string[0, temp_pos].strip
-      temp_string = temp_string[(temp_pos + 1)..].strip
-    end
-
-    # split remaining string by space
-    temp_pos = nil
-    if (@creditsOverlay.text_size(temp_string).width > max_width) && (start_pos = temp_string.index(' '))
-      while start_pos && (@creditsOverlay.text_size(temp_string).width > max_width)
-        substring_width = @creditsOverlay.text_size(temp_string[0, start_pos]).width
-        if substring_width > max_width
-          name_split << temp_string[0, temp_pos].strip
-          temp_string = temp_string[(temp_pos + 1)..].strip
-          start_pos = temp_string.index(' ')
-          temp_pos = nil
-          next
-        end
-
-        temp_pos = start_pos
-        start_pos = temp_string.index(' ', start_pos + 1)
-      end
-    end
-
-    # append remaining text, even if too long for screen
-    name_split << temp_string if temp_string != ''
-
-    longest_line_width = name_split.map { |n| @creditsOverlay.text_size(n).width }.max
-    return name_split
-  end
-
   def showSpriteCredits(filename, generated_sprite = false)
     @creditsOverlay.dispose
 
@@ -299,16 +242,15 @@ class PokemonPokedexInfo_Scene
     discord_name = "Imported sprite" if @selected_pif_sprite.local_path
     author_name = File.basename(discord_name, '#*')
 
+    x = Graphics.width / 2
     label_base_color = Color.new(248, 248, 248)
     label_shadow_color = Color.new(104, 104, 104)
     @creditsOverlay = BitmapSprite.new(Graphics.width, Graphics.height, @viewport).bitmap
-    split_name = splitSpriteCredits(author_name)
+    split_name = splitSpriteCredits(author_name, @creditsOverlay, @creditsOverlay.width - 20)
     line_height = @creditsOverlay.text_size(author_name).height
     textpos = split_name.each_with_index.map { |name, index|
-      text_width = @creditsOverlay.text_size(name).width
-      x = (Graphics.width - text_width) / 2
       y = (Graphics.height - 60) + (line_height * ((index + 1) - ((split_name.length.to_f + 1) / 2)))
-      [name, x, y, 0, label_base_color, label_shadow_color]
+      [name, x, y, 2, label_base_color, label_shadow_color]
     }
     pbDrawTextPositions(@creditsOverlay, textpos)
   end

--- a/Data/Scripts/052_AddOns/UI_Pokedex_SpritesPage.rb
+++ b/Data/Scripts/052_AddOns/UI_Pokedex_SpritesPage.rb
@@ -227,6 +227,63 @@ class PokemonPokedexInfo_Scene
     update_selected
   end
 
+  def splitSpriteCredits(name)
+    max_width = @creditsOverlay.width - 20
+    name_full_width = @creditsOverlay.text_size(name).width
+    # use original name if can fit on one line
+    return [ name ] if name_full_width <= max_width
+
+    temp_string = name
+    name_split = []
+
+    # split name by collab separator " & " up to screen width
+    start_pos = temp_string.index(' & ')
+    temp_pos = nil
+    while start_pos && (@creditsOverlay.text_size(temp_string).width > max_width)
+      substring_width = @creditsOverlay.text_size(temp_string[0, start_pos]).width
+      if substring_width > max_width
+        name_split << temp_string[0, temp_pos].strip
+        temp_string = temp_string[(temp_pos + 1)..].strip
+        start_pos = temp_string.index(' & ')
+        temp_pos = nil
+        next
+      end
+
+      temp_pos = start_pos
+      start_pos = temp_string.index(' & ', start_pos + 1)
+    end
+
+    # append remainder of " & " split if within max width
+    if temp_pos != nil
+      name_split << temp_string[0, temp_pos].strip
+      temp_string = temp_string[(temp_pos + 1)..].strip
+    end
+
+    # split remaining string by space
+    temp_pos = nil
+    if (@creditsOverlay.text_size(temp_string).width > max_width) && (start_pos = temp_string.index(' '))
+      while start_pos && (@creditsOverlay.text_size(temp_string).width > max_width)
+        substring_width = @creditsOverlay.text_size(temp_string[0, start_pos]).width
+        if substring_width > max_width
+          name_split << temp_string[0, temp_pos].strip
+          temp_string = temp_string[(temp_pos + 1)..].strip
+          start_pos = temp_string.index(' ')
+          temp_pos = nil
+          next
+        end
+
+        temp_pos = start_pos
+        start_pos = temp_string.index(' ', start_pos + 1)
+      end
+    end
+
+    # append remaining text, even if too long for screen
+    name_split << temp_string if temp_string != ''
+
+    longest_line_width = name_split.map { |n| @creditsOverlay.text_size(n).width }.max
+    return name_split
+  end
+
   def showSpriteCredits(filename, generated_sprite = false)
     @creditsOverlay.dispose
 
@@ -245,9 +302,14 @@ class PokemonPokedexInfo_Scene
     label_base_color = Color.new(248, 248, 248)
     label_shadow_color = Color.new(104, 104, 104)
     @creditsOverlay = BitmapSprite.new(Graphics.width, Graphics.height, @viewport).bitmap
-    x = (Graphics.width - @creditsOverlay.text_size(author_name).width) / 2
-    y = Graphics.height - 60
-    textpos = [[author_name, x, y, 0, label_base_color, label_shadow_color]]
+    split_name = splitSpriteCredits(author_name)
+    line_height = @creditsOverlay.text_size(author_name).height
+    textpos = split_name.each_with_index.map { |name, index|
+      text_width = @creditsOverlay.text_size(name).width
+      x = (Graphics.width - text_width) / 2
+      y = (Graphics.height - 60) + (line_height * ((index + 1) - ((split_name.length.to_f + 1) / 2)))
+      [name, x, y, 0, label_base_color, label_shadow_color]
+    }
     pbDrawTextPositions(@creditsOverlay, textpos)
   end
 

--- a/Data/Scripts/052_AddOns/UI_Pokedex_SpritesPage.rb
+++ b/Data/Scripts/052_AddOns/UI_Pokedex_SpritesPage.rb
@@ -230,8 +230,6 @@ class PokemonPokedexInfo_Scene
   def showSpriteCredits(filename, generated_sprite = false)
     @creditsOverlay.dispose
 
-    x = Graphics.width / 2 - 75
-    y = Graphics.height - 60
     spritename = File.basename(filename, '.*')
 
     if !generated_sprite
@@ -247,6 +245,8 @@ class PokemonPokedexInfo_Scene
     label_base_color = Color.new(248, 248, 248)
     label_shadow_color = Color.new(104, 104, 104)
     @creditsOverlay = BitmapSprite.new(Graphics.width, Graphics.height, @viewport).bitmap
+    x = (Graphics.width - @creditsOverlay.text_size(author_name).width) / 2
+    y = Graphics.height - 60
     textpos = [[author_name, x, y, 0, label_base_color, label_shadow_color]]
     pbDrawTextPositions(@creditsOverlay, textpos)
   end


### PR DESCRIPTION
Splits spriter credits onto multiple lines to prevent/reduce occurences when long credit entries (collabs) run off the screen.

Fusion Screen:
![multiline-comparision-fusion](https://github.com/user-attachments/assets/4c8e8e9e-6313-4dfa-82c5-03d709ac94fb)

Sprite Selection Screen:
![multiline-comparison-selection](https://github.com/user-attachments/assets/a3363903-b7b3-4304-874d-ccfb39d4e095)
