### PR TITLE
Multiple bug fixes

### DIFF
--- a/Data/Scripts/011_Battle/003_Battle/004_Battle_ExpAndMoveLearning.rb
+++ b/Data/Scripts/011_Battle/003_Battle/004_Battle_ExpAndMoveLearning.rb
@@ -190,6 +190,15 @@ class PokeBattle_Battle
     end
     tempExp1 = pkmn.exp
     battler = pbFindBattler(idxParty)
+
+    if pkmn.isFusion?
+      if pkmn.exp_gained_since_fused == nil
+        pkmn.exp_gained_since_fused = expGained
+      else
+        pkmn.exp_gained_since_fused += expGained
+      end
+    end
+
     loop do
       # For each level gained in turn...
       # EXP Bar animation
@@ -198,16 +207,6 @@ class PokeBattle_Battle
       tempExp2 = (levelMaxExp < expFinal) ? levelMaxExp : expFinal
       pkmn.exp = tempExp2
 
-
-
-      if pkmn.isFusion?
-        if pkmn.exp_gained_since_fused == nil
-          pkmn.exp_gained_since_fused = expGained
-        else
-          pkmn.exp_gained_since_fused += expGained
-        end
-
-      end
       @scene.pbEXPBar(battler, levelMinExp, levelMaxExp, tempExp1, tempExp2) if !dontAnimate
 
 

--- a/Data/Scripts/014_Pokemon/001_Pokemon.rb
+++ b/Data/Scripts/014_Pokemon/001_Pokemon.rb
@@ -968,8 +968,9 @@ class Pokemon
 
   def pokemon_can_learn_move(species_data, move_data)
     return species_data.tutor_moves.include?(move_data.id) ||
-      species_data.moves.include?(move_data.id) ||
-      species_data.egg_moves.include?(move_data.id)
+      species_data.moves.any? { |move| move[1] == move_data.id } ||
+      species_data.egg_moves.include?(move_data.id) ||
+      GameData::Species.get(species_data.get_baby_species()).egg_moves.include?(move_data.id)
   end
 
   def can_relearn_move?

--- a/Data/Scripts/025-Randomizer/RandomizerUtils.rb
+++ b/Data/Scripts/025-Randomizer/RandomizerUtils.rb
@@ -88,12 +88,7 @@ def pbGetRandomItem(item_id)
   return nil if item_id == nil
   item = GameData::Item.get(item_id)
   return item if !($game_switches[SWITCH_RANDOM_ITEMS] || $game_switches[SWITCH_RANDOM_TMS])
-  if $game_switches[SWITCH_RANDOM_ITEMS_MAPPED]
-    return getMappedRandomItem(item)
-  # elsif $game_switches[SWITCH_RANDOM_ITEMS_DYNAMIC]
-  #   return getDynamicRandomItem(item)
-  end
-  return item
+  return getMappedRandomItem(item)
 end
 
 def pbGetRandomHeldItem()

--- a/Data/Scripts/048_Fusion/FusedSpecies.rb
+++ b/Data/Scripts/048_Fusion/FusedSpecies.rb
@@ -168,7 +168,7 @@ module GameData
     end
 
     def calculate_moveset
-      return combine_arrays(@body_pokemon.moves, @head_pokemon.moves)
+      return combine_moves(@body_pokemon.moves, @head_pokemon.moves)
     end
 
     def calculate_egg_moves
@@ -397,6 +397,25 @@ module GameData
 
     def combine_arrays(array1, array2)
       return array1 + array2
+    end
+
+    def combine_moves(array1, array2)
+      # Sort the moves while preserving the order between moves learnt in the same level
+      return array1 if array2.empty?
+      return array2 if array1.empty?
+      output = []
+      i = 0
+      array2.each do |b|
+        while i < array1.length
+          a = array1[i]
+          break if a[0] > b[0]
+          output.push(a)
+          i += 1
+        end
+        output.push(b) unless output.include?(b)
+      end
+      output += array1.slice(i) if i < array1.length
+      return output
     end
 
   end

--- a/Data/Scripts/052_AddOns/FusionMoveTutor.rb
+++ b/Data/Scripts/052_AddOns/FusionMoveTutor.rb
@@ -128,7 +128,7 @@ class FusionTutorService
       #compatibleMoves << :SPIKYSHIELD if is_fusion_of([:FERROSEED, :FERROTHORN]) || (is_fusion_of([:SANDSLASH, :JOLTEON, :CLOYSTER]) && hasType(:GRASS))
       compatibleMoves << :STRENGTHSAP if is_fusion_of([:ODDISH, :GLOOM, :VILEPLUME, :BELLOSSOM, :HOPPIP, :SKIPLOOM, :JUMPLUFF, :BELLSPROUT, :WEEPINBELL, :VICTREEBEL, :PARAS, :PARASECT, :DRIFBLIM, :BRELOOM])
       #compatibleMoves << :SHOREUP if is_fusion_of([:GRIMER, :MUK]) && hasType(:GROUND)
-      compatibleMoves << :ICEHAMMER if (canLearnMove(:CRABHAMMER) || canLearnMove(:GRASSHAMMER) || canLearnMove(:HAMMERARM)) && hasType(:ICE)
+      compatibleMoves << :ICEHAMMER if (canLearnMove(:CRABHAMMER) || canLearnMove(:WOODHAMMER) || canLearnMove(:HAMMERARM)) && hasType(:ICE)
       compatibleMoves << :MULTIATTACK if is_fusion_of([:ARCEUS, :MEW, :GENESECT])
       # compatibleMoves << :REVELATIONDANCE if is_fusion_of([:KECLEON, :BELLOSSOM, :CLEFAIRY, :CLEFABLE, :CLEFFA])
       #compatibleMoves << :BANEFULBUNKER if is_fusion_of([:TENTACOOL, :TENTACRUEL, :NIDORINA, :NIDORINO, :NIDOQUEEN, :NIDOKING, :GRIMER, :MUK, :QWILFISH])


### PR DESCRIPTION
- Fix move experts cannot teach certain moves (Ice Hammer, Magma Storm, Double Iron Bash, Steam Eruption)
- Fix trainer's fused Pokémon only learn moves from head Pokémon (they only start learning moves from body Pokémon when head does not have 4 moves available).
- Fix TM randomization does not work when Found Items is not active. (#142)
- Fix unfusing Pokémon gains exp after leveling up multiple times through fainting a single Pokémon (#145)