### PR TITLE
Add nil check when replaced Pokemon not found

### DIFF
--- a/Data/Scripts/052_InfiniteFusion/System/GameModes/LegendaryMode.rb
+++ b/Data/Scripts/052_InfiniteFusion/System/GameModes/LegendaryMode.rb
@@ -123,10 +123,12 @@ def getNewLegendaryFusionForGymType(original_species, nb_retries = 0)
 
   legendary_species = LEGENDARIES_LIST.sample
 
-  if pokemon_to_be_replaced.species == head_species.species
-    head_species_id = legendary_species
-  else
-    body_species_id = legendary_species
+  if !pokemon_to_be_replaced.nil?
+    if pokemon_to_be_replaced.species == head_species.species
+	  head_species_id = legendary_species
+	else
+      body_species_id = legendary_species
+	end
   end
   echoln "picked #{head_species_id}/#{body_species_id}"
   echoln "custom sprite exists: #{customSpriteExists(body_species_id, head_species_id)}"


### PR DESCRIPTION
Currently the game will crash at line 126 of `getNewLegendaryFusionForGymType` if `pokemon_to_be_replaced` is Nil.

<img width="1029" height="813" alt="image" src="https://github.com/user-attachments/assets/4f4aa4c8-919d-413b-8c87-12ee43cea92a" />

Adding a Nil check on line 126 safely guards against this at the cost of this trainer having a non-legendary Pokemon in their roster, in this case Marowak. (screenshot just do display error no longer occurs)

<img width="1026" height="807" alt="infinite-fusion-legendary-fix" src="https://github.com/user-attachments/assets/9870042e-2fbb-4c27-9ca1-082e87eab82d" />
